### PR TITLE
fix: allow creating audit log configs without IAM bindings or members

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.4]
+
+### Fixed
+
+- Allow to only create audit configs (without defining IAM bindings or memberships)
+
 ## [0.0.3]
 
 ### Added
+
 - Add support for `google_project_iam_audit_config` resource
 
 ## [0.0.2]
@@ -25,7 +32,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial Implementation
 
-[unreleased]: https://github.com/mineiros-io/terraform-google-organization-iam/compare/v0.0.3...HEAD
+[unreleased]: https://github.com/mineiros-io/terraform-google-organization-iam/compare/v0.0.4...HEAD
+[0.0.4]: https://github.com/mineiros-io/terraform-google-organization-iam/compare/v0.0.3...v0.0.4
 [0.0.3]: https://github.com/mineiros-io/terraform-google-organization-iam/compare/v0.0.2...v0.0.3
 [0.0.2]: https://github.com/mineiros-io/terraform-google-organization-iam/compare/v0.0.1...v0.0.2
 [0.0.1]: https://github.com/mineiros-io/terraform-google-organization-iam/releases/tag/v0.0.1

--- a/Makefile
+++ b/Makefile
@@ -105,7 +105,7 @@ test/unit-tests:
 ## Generate README.md with Terradoc
 .PHONY: terradoc
 terradoc:
-	$(call quiet-command,terradoc -o README.md README.tfdoc.hcl)
+	$(call quiet-command,terradoc generate README.tfdoc.hcl >README.md)
 
 ## Clean up cache and temporary files
 .PHONY: clean

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Most basic usage just setting required arguments:
 
 ```hcl
 module "terraform-google-organization-iam" {
-  source = "github.com/mineiros-io/terraform-google-organization-iam?ref=v0.0.2"
+  source = "github.com/mineiros-io/terraform-google-organization-iam?ref=v0.0.4"
 
   org_id  = "your-organization-id"
   role    = "roles/editor"

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ See [variables.tf] and [examples/] for details and use-cases.
 
       An optional description of the expression. This is a longer text which describes the expression, e.g. when hovered over it in a UI.
 
-- [**`audit_configs`**](#var-audit_configs): *(Optional `object(audit_log)`)*<a name="var-audit_configs"></a>
+- [**`audit_configs`**](#var-audit_configs): *(Optional `object(audit_config)`)*<a name="var-audit_configs"></a>
 
   List of audit logs settings to be enabled.
 
@@ -191,7 +191,7 @@ See [variables.tf] and [examples/] for details and use-cases.
   ]
   ```
 
-  The `audit_log` object accepts the following attributes:
+  The `audit_config` object accepts the following attributes:
 
   - [**`service`**](#attr-audit_configs-service): *(**Required** `string`)*<a name="attr-audit_configs-service"></a>
 

--- a/README.tfdoc.hcl
+++ b/README.tfdoc.hcl
@@ -65,7 +65,7 @@ section {
 
       ```hcl
       module "terraform-google-organization-iam" {
-        source = "github.com/mineiros-io/terraform-google-organization-iam?ref=v0.0.2"
+        source = "github.com/mineiros-io/terraform-google-organization-iam?ref=v0.0.4"
 
         org_id  = "your-organization-id"
         role    = "roles/editor"

--- a/main.tf
+++ b/main.tf
@@ -1,9 +1,11 @@
 locals {
-  audit_configs_map = { for c in var.audit_configs : c.service => c }
+  create_binding = var.policy_bindings == null && var.role != null && var.authoritative
+  create_member  = var.policy_bindings == null && var.role != null && var.authoritative == false
+  create_policy  = var.policy_bindings != null
 }
 
 resource "google_organization_iam_binding" "binding" {
-  count = var.module_enabled && var.policy_bindings == null && var.authoritative ? 1 : 0
+  count = var.module_enabled && local.create_binding ? 1 : 0
 
   depends_on = [var.module_depends_on]
 
@@ -24,7 +26,7 @@ resource "google_organization_iam_binding" "binding" {
 }
 
 resource "google_organization_iam_member" "member" {
-  for_each = var.module_enabled && var.policy_bindings == null && var.authoritative == false ? var.members : []
+  for_each = var.module_enabled && local.create_member ? var.members : []
 
   org_id = var.org_id
   role   = var.role
@@ -43,7 +45,7 @@ resource "google_organization_iam_member" "member" {
 }
 
 resource "google_organization_iam_policy" "policy" {
-  count = var.module_enabled && var.policy_bindings != null ? 1 : 0
+  count = var.module_enabled && local.create_policy ? 1 : 0
 
   org_id      = var.org_id
   policy_data = data.google_iam_policy.policy[0].policy_data
@@ -51,25 +53,8 @@ resource "google_organization_iam_policy" "policy" {
   depends_on = [var.module_depends_on]
 }
 
-resource "google_organization_iam_audit_config" "organization" {
-  for_each = var.module_enabled ? local.audit_configs_map : {}
-
-  org_id = var.org_id
-
-  service = each.value.service
-
-  dynamic "audit_log_config" {
-    for_each = each.value.audit_log_configs
-
-    content {
-      log_type         = audit_log_config.value.log_type
-      exempted_members = try(audit_log_config.value.exempted_members, null)
-    }
-  }
-}
-
 data "google_iam_policy" "policy" {
-  count = var.module_enabled && var.policy_bindings != null ? 1 : 0
+  count = var.module_enabled && local.create_policy ? 1 : 0
 
   dynamic "binding" {
     for_each = var.policy_bindings
@@ -87,6 +72,27 @@ data "google_iam_policy" "policy" {
           description = try(condition.value.description, null)
         }
       }
+    }
+  }
+}
+
+locals {
+  audit_configs_map = { for c in var.audit_configs : c.service => c }
+}
+
+resource "google_organization_iam_audit_config" "organization" {
+  for_each = var.module_enabled ? local.audit_configs_map : {}
+
+  org_id = var.org_id
+
+  service = each.value.service
+
+  dynamic "audit_log_config" {
+    for_each = each.value.audit_log_configs
+
+    content {
+      log_type         = audit_log_config.value.log_type
+      exempted_members = try(audit_log_config.value.exempted_members, null)
     }
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -16,6 +16,7 @@ variable "org_id" {
 variable "role" {
   type        = string
   description = "(Optional) The role that should be applied. Only one google_project_iam_binding can be used per role. Note that custom roles must be of the format organizations/{{org_id}}/roles/{{role_id}}."
+  default     = null
 }
 
 variable "members" {


### PR DESCRIPTION
- fix: allow creating audit log configs without IAM bindings or members
- fix: new terradoc syntax
- chore: prepare 0.0.4 release
